### PR TITLE
都道府県選択状態の保持機能を修正

### DIFF
--- a/app/stores/page.tsx
+++ b/app/stores/page.tsx
@@ -76,6 +76,16 @@ function StoresPageContent() {
     return area?.name || '不明'
   }
 
+  const getPrefectureFromAreaIds = () => {
+    if (!area_ids || !areas.length) return ''
+    const areaIdArray = area_ids.split(',').map(id => parseInt(id.trim(), 10))
+    const selectedAreas = areas.filter(area => areaIdArray.includes(area.id))
+    if (selectedAreas.length > 0) {
+      return selectedAreas[0].prefecture
+    }
+    return ''
+  }
+
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
@@ -108,6 +118,7 @@ function StoresPageContent() {
             書店一覧
           </h1>
           <SearchForm 
+            initialPrefecture={getPrefectureFromAreaIds()}
             initialArea={area}
             initialCategory={category}
             initialSearch={search}

--- a/components/store/search-form.tsx
+++ b/components/store/search-form.tsx
@@ -28,6 +28,10 @@ export function SearchForm({
     fetchAreas()
   }, [])
 
+  useEffect(() => {
+    setPrefecture(initialPrefecture)
+  }, [initialPrefecture])
+
   const fetchAreas = async () => {
     try {
       const response = await fetch('/api/areas')


### PR DESCRIPTION
- 書店一覧ページでarea_idsパラメータから都道府県を逆算するgetPrefectureFromAreaIds関数を追加
- SearchFormにinitialPrefectureプロパティを渡すように修正
- SearchFormでinitialPrefectureが変更されたときに状態を更新するuseEffectを追加
- 検索後に都道府県プルダウンの選択状態が保持されるように修正